### PR TITLE
Fix: Address parsing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace 'supersocksr.ppp.android'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId 'supersocksr.ppp.android'
         minSdk 24
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 
@@ -92,6 +92,11 @@ dependencies {
     // OkHttp
     implementation(platform(libs.okhttp.bom))
     implementation(libs.okhttp)
+
+    // Named regex: https://github.com/tony19/named-regexp
+    // Why: https://stackoverflow.com/questions/32776168/regex-pattern-in-android-studio-throws-error-this-named-group-syntax-is-not-su
+    // But I tried, it's weak, so we don't use it.
+    // implementation libs.tony19.named.regexp
 
     //noinspection GradleDependency
     implementation libs.gson

--- a/app/src/main/java/supersocksr/ppp/android/MainActivity.kt
+++ b/app/src/main/java/supersocksr/ppp/android/MainActivity.kt
@@ -389,7 +389,7 @@ class MainActivity : PppVpnActivity() {
             contentAlignment = Alignment.Center
           ) {
             Text(
-              text = config.name.ifEmpty { config.server.host },
+              text = config.name.ifEmpty { config.server.host.orEmpty() },
               fontSize = 14.sp,
               color = MaterialTheme.colorScheme.onPrimary,
               overflow = TextOverflow.Ellipsis
@@ -601,8 +601,8 @@ class MainActivity : PppVpnActivity() {
             try {
               val cfg = UserConfig(
                 name = name.text.trim(),
-                server = Address.parse(server.text.trim()),
-                static_server = Address.parse(static_server.text.trim()),
+                server = Address.unsafeParse(server.text.trim()),
+                static_server = Address.unsafeParse(static_server.text.trim()),
                 guid = guid.text.trim(),
                 tun_address = tun_address.text.trim()
                   .let { if (it.isBlank()) null else Address.parse(it) },
@@ -611,7 +611,7 @@ class MainActivity : PppVpnActivity() {
               onSave(cfg)
             } catch (e: Exception) {
               e.printStackTrace()
-              Toast.makeText(this, "Invalid URI: ${e.message}", Toast.LENGTH_LONG)
+              Toast.makeText(this, "Invalid Address: ${e.message}", Toast.LENGTH_LONG)
                 .show()
             }
           }

--- a/app/src/main/java/supersocksr/ppp/android/MainActivity.kt
+++ b/app/src/main/java/supersocksr/ppp/android/MainActivity.kt
@@ -1,6 +1,5 @@
 package supersocksr.ppp.android
 
-import Address
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
@@ -49,6 +48,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,6 +81,7 @@ import supersocksr.ppp.android.openppp2.Macro
 import supersocksr.ppp.android.openppp2.VPNLinkConfiguration
 import supersocksr.ppp.android.ui.theme.Openppp2Theme
 import supersocksr.ppp.android.ui.theme.Pink500
+import supersocksr.ppp.android.utils.Address
 import supersocksr.ppp.android.utils.RawReader
 import supersocksr.ppp.android.utils.UserConfig
 import java.net.ConnectException
@@ -95,11 +96,11 @@ const val TAG = "MainActivity"
 const val ALL_CONFIGS_KEY = "all_configs"
 
 class MainActivity : PppVpnActivity() {
-  val userConfigListSerializer = ListSerializer(UserConfig.serializer())
-  lateinit var configPreferences: SharedPreferences
-  lateinit var settingsPreferences: SharedPreferences
-  lateinit var settings: Settings
-  val selectedUserConfig: MutableState<UserConfig?> = mutableStateOf(null)
+  private val userConfigListSerializer = ListSerializer(UserConfig.serializer())
+  private lateinit var configPreferences: SharedPreferences
+  private lateinit var settingsPreferences: SharedPreferences
+  private lateinit var settings: Settings
+  private val selectedUserConfig: MutableState<UserConfig?> = mutableStateOf(null)
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -174,7 +175,7 @@ class MainActivity : PppVpnActivity() {
             keep_alived[1] = 0
             aggligator = 0
             servers.add(selectedUserConfig.value!!.static_server.toString())
-            Log.d(TAG, "udp static servers: ${servers}")
+            Log.d(TAG, "udp static servers: $servers")
           }
         }
 
@@ -223,7 +224,7 @@ class MainActivity : PppVpnActivity() {
   }
 
   // FIXME: this function actually cannot hide ime.
-  fun hideIME(view: View? = null) {
+  private fun hideIME(view: View? = null) {
     val focusedView = currentFocus
     if (focusedView !is TextInputEditText) {
       return
@@ -238,7 +239,7 @@ class MainActivity : PppVpnActivity() {
   @Composable
   fun App() {
     val navController = rememberNavController()
-    val selectedTab = remember { mutableStateOf(0) } // 当前选中的按钮索引
+    val selectedTab = remember { mutableIntStateOf(0) } // 当前选中的按钮索引
 
     Scaffold(
       bottomBar = {
@@ -611,7 +612,11 @@ class MainActivity : PppVpnActivity() {
               onSave(cfg)
             } catch (e: Exception) {
               e.printStackTrace()
-              Toast.makeText(this, "Invalid Address: ${e.message}", Toast.LENGTH_LONG)
+              Toast.makeText(
+                this,
+                "Invalid supersocksr.ppp.android.utils.Address: ${e.message}",
+                Toast.LENGTH_LONG
+              )
                 .show()
             }
           }
@@ -630,7 +635,7 @@ class MainActivity : PppVpnActivity() {
   }
 
   // 测试连接
-  fun testConnection(state: MutableState<String>) {
+  private fun testConnection(state: MutableState<String>) {
     Log.i(TAG, "testConnection starting..")
     lifecycleScope.launch(Dispatchers.IO) {
       val url = URL(settingsPreferences.getString(TEST_LINK_KEY, TEST_LINK_DEFAULT)!!)

--- a/app/src/main/java/supersocksr/ppp/android/utils/Address.kt
+++ b/app/src/main/java/supersocksr/ppp/android/utils/Address.kt
@@ -1,3 +1,5 @@
+package supersocksr.ppp.android.utils
+
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -10,9 +12,9 @@ data class Address(
 ) {
 
   companion object {
-    val addressRegex = Regex(
+    private val addressRegex = Regex(
       "^(?:([a-zA-Z][a-zA-Z0-9+.-]*)://)?" +  // Group 1: scheme
-              "(?:([^\\[\\]:/]+)?)" +                 // Group 2: host
+              "([^\\[\\]:/]+)?" +                 // Group 2: host
               "(?:\\[([^]]+)])?" +                    // Group 3: ip
               "(?::(\\d+))?" +                        // Group 4: port
               "(/.*)?"                                // Group 5: path

--- a/app/src/main/java/supersocksr/ppp/android/utils/Address.kt
+++ b/app/src/main/java/supersocksr/ppp/android/utils/Address.kt
@@ -1,31 +1,59 @@
 import kotlinx.serialization.Serializable
-import java.net.URI
 
 @Serializable
-data class Address(var scheme: String?, val host: String, val port: Int?) {
+data class Address(
+  var scheme: String? = null,
+  val host: String? = null,
+  val additional_ip: String? = null,
+  val port: Int? = null,
+  val path: String? = null,
+) {
 
   companion object {
-    fun parse(address: String): Address {
-      val uri =
-        URI.create(if (address.contains("://")) address else "//$address")  // 确保 scheme 存在，否则 URI 解析会失败
-      return Address(
-        scheme = uri.scheme,
-        host = uri.host ?: throw IllegalArgumentException("Invalid host"),
-        port = if (uri.port == -1) null else uri.port
-      )
-    }
+    val addressRegex = Regex(
+      "^(?:([a-zA-Z][a-zA-Z0-9+.-]*)://)?" +  // Group 1: scheme
+              "(?:([^\\[\\]:/]+)?)" +                 // Group 2: host
+              "(?:\\[([^]]+)])?" +                    // Group 3: ip
+              "(?::(\\d+))?" +                        // Group 4: port
+              "(/.*)?"                                // Group 5: path
+    )
 
-    fun tryParse(address: String): Address? {
+    fun parse(input: String): Address? {
       return try {
-        parse(address)
-      } catch (e: IllegalArgumentException) {
+        unsafeParse(input)
+      } catch (e: Exception) {
         null
       }
+    }
+
+    fun unsafeParse(input: String): Address {
+      val matchResult = addressRegex.matchEntire(input)
+        ?: throw IllegalArgumentException("address not match regex.")
+      val scheme = matchResult.groupValues.getOrNull(1)?.let { it.ifEmpty { null } }
+      val host = matchResult.groupValues.getOrNull(2)?.let { it.ifEmpty { null } }
+      val ip = matchResult.groupValues.getOrNull(3)?.let { it.ifEmpty { null } }
+      val port = matchResult.groupValues.getOrNull(4)?.let { it.ifEmpty { null } }
+      val path = matchResult.groupValues.getOrNull(5)?.let { it.ifEmpty { null } }
+      return Address(scheme, host, ip, port?.toInt(), path)
     }
   }
 
   override fun toString(): String {
-    return "${scheme?.let { "$it://" } ?: ""}$host${port?.let { ":$it" } ?: ""}"
+    val sb = StringBuilder()
+    if (scheme != null) sb.append("$scheme://")
+    if (host != null) sb.append(host)
+    if (additional_ip != null) sb.append("[$additional_ip]")
+    if (port != null) sb.append(":$port")
+    if (path != null) sb.append(path)
+    return sb.toString()
+  }
+
+  fun debug() {
+    println("scheme: $scheme")
+    println("host: $host")
+    println("additional_ip: $additional_ip")
+    println("port: $port")
+    println("path: $path")
   }
 
   override fun equals(other: Any?): Boolean {
@@ -34,18 +62,7 @@ data class Address(var scheme: String?, val host: String, val port: Int?) {
 
     other as Address
 
-    if (scheme != other.scheme) return false
-    if (host != other.host) return false
-    if (port != other.port) return false
-
-    return true
-  }
-
-  override fun hashCode(): Int {
-    var result = scheme?.hashCode() ?: 0
-    result = 31 * result + host.hashCode()
-    result = 31 * result + (port ?: 0)
-    return result
+    return scheme == other.scheme && host == other.host && port == other.port && path == other.path && additional_ip == other.additional_ip
   }
 
   fun hasScheme(): Boolean {
@@ -54,6 +71,27 @@ data class Address(var scheme: String?, val host: String, val port: Int?) {
 
   fun hasPort(): Boolean {
     return port != null
+  }
+
+  fun hasAdditionalIp(): Boolean {
+    return additional_ip != null
+  }
+
+  fun hasPath(): Boolean {
+    return path != null
+  }
+
+  fun hasHost(): Boolean {
+    return host != null
+  }
+
+  override fun hashCode(): Int {
+    var result = scheme?.hashCode() ?: 0
+    result = 31 * result + (host?.hashCode() ?: 0)
+    result = 31 * result + (additional_ip?.hashCode() ?: 0)
+    result = 31 * result + (port ?: 0)
+    result = 31 * result + (path?.hashCode() ?: 0)
+    return result
   }
 
 }

--- a/app/src/main/java/supersocksr/ppp/android/utils/UserConfig.kt
+++ b/app/src/main/java/supersocksr/ppp/android/utils/UserConfig.kt
@@ -1,6 +1,5 @@
 package supersocksr.ppp.android.utils
 
-import Address
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/app/src/main/java/supersocksr/ppp/android/utils/UserConfig.kt
+++ b/app/src/main/java/supersocksr/ppp/android/utils/UserConfig.kt
@@ -6,18 +6,19 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UserConfig(
   val name: String = "",
-  val server: Address = Address.parse("ppp://127.0.0.1:1080"),
-  val static_server: Address = Address.parse("192.168.0.24:20000"),
+  val server: Address = Address.unsafeParse("ppp://127.0.0.1:1080"),
+  val static_server: Address = Address.unsafeParse("192.168.0.24:20000"),
   val guid: String = "Random",
-  val tun_address: Address? = Address.parse("10.0.0.214"),
+  val tun_address: Address? = Address.unsafeParse("10.0.0.214"),
 ) {
-
   fun validate() {
+    // supplement
     if (!server.hasScheme()) {
       server.scheme = "ppp"
     }
-    if (!server.hasPort()) {
-      throw IllegalArgumentException("server port cannot be empty")
+    // check
+    if (server.scheme == "ppp" && !server.hasPort()) {
+      throw IllegalArgumentException("ppp server port cannot be empty")
     }
     if (!static_server.hasPort()) {
       throw IllegalArgumentException("static_server port cannot be empty")

--- a/app/src/test/java/supersocksr/ppp/android/utils/AddressTest.kt
+++ b/app/src/test/java/supersocksr/ppp/android/utils/AddressTest.kt
@@ -8,15 +8,34 @@ class AddressTest {
 
   @Test
   fun testToString() {
-    assertEquals("89.0.142.86", Address(null, "89.0.142.86", null).toString())
+    assertEquals("89.0.142.86", Address(null, "89.0.142.86").toString())
     assertEquals("https://89.0.142.86", Address("https", "89.0.142.86", null).toString())
-    assertEquals("ppp://89.0.142.86:20000", Address("ppp", "89.0.142.86", 20000).toString())
+    assertEquals("ppp://89.0.142.86:20000", Address("ppp", "89.0.142.86", port = 20000).toString())
+    assertEquals(
+      "ws://www.baidu.com[127.0.0.1]:899/tun",
+      Address("ws", "www.baidu.com", "127.0.0.1", 899, "/tun").toString()
+    )
+    assertEquals(
+      "ws://www.baidu.com[127.0.0.1]/tun",
+      Address("ws", "www.baidu.com", "127.0.0.1", null, "/tun").toString()
+    )
   }
 
   @Test
   fun testParse() {
-    assertEquals(Address(null, "89.0.142.86", null), Address.parse("89.0.142.86"))
-    assertEquals(Address("https", "89.0.142.86", null), Address.parse("https://89.0.142.86"))
-    assertEquals(Address("ppp", "89.0.142.86", 20000), Address.parse("ppp://89.0.142.86:20000"))
+    assertEquals(Address(host = "89.0.142.86"), Address.unsafeParse("89.0.142.86"))
+    assertEquals(Address("https", "89.0.142.86", null), Address.unsafeParse("https://89.0.142.86"))
+    assertEquals(
+      Address("ppp", "89.0.142.86", port = 20000),
+      Address.unsafeParse("ppp://89.0.142.86:20000")
+    )
+    assertEquals(
+      Address("ws", "www.baidu.com", "127.0.0.1", 899, "/tun"),
+      Address.unsafeParse("ws://www.baidu.com[127.0.0.1]:899/tun")
+    )
+    assertEquals(
+      Address("ws", "www.baidu.com", "127.0.0.1", null, "/tun"),
+      Address.unsafeParse("ws://www.baidu.com[127.0.0.1]/tun")
+    )
   }
 }

--- a/app/src/test/java/supersocksr/ppp/android/utils/AddressTest.kt
+++ b/app/src/test/java/supersocksr/ppp/android/utils/AddressTest.kt
@@ -1,6 +1,5 @@
 package supersocksr.ppp.android.utils
 
-import Address
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,17 +2,18 @@
 activityCompose = "1.9.3"
 androidProcesses = "1.1.1"
 annotations = "23.0.0"
-composeBom = "2024.10.00"
-coreKtx = "1.13.1"
+composeBom = "2024.10.01"
+coreKtx = "1.15.0"
 espressoCore = "3.6.1"
 gson = "2.10.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 kotlin = "2.0.20"
-kotlinapp = "8.7.1"
+kotlinapp = "8.7.2"
 kotlinxCoroutinesCore = "1.8.0"
 kotlinxSerializationJson = "1.7.1"
 material = "1.12.0"
+namedRegexpVersion = "1.0.0"
 navigationCompose = "2.8.3"
 navigationRuntimeKtx = "2.8.3"
 okhttpBom = "4.12.0"
@@ -40,6 +41,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 material = { module = "com.google.android.material:material", version.ref = "material" }
 okhttp = { module = "com.squareup.okhttp3:okhttp" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttpBom" }
+tony19-named-regexp = { module = "com.github.tony19:named-regexp", version.ref = "namedRegexpVersion" }
 ui-tiles = { module = "com.github.alorma.compose-settings:ui-tiles", version.ref = "uiTiles" }
 ui-tiles-extended = { module = "com.github.alorma.compose-settings:ui-tiles-extended", version.ref = "uiTilesExtended" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junitJupiter" }


### PR DESCRIPTION
The previous Address parsing implemention would only parse standard URI.
Now it has been enhanced to parse something like `ws://www.baidu.com[127.0.0.1]:899/tun`.